### PR TITLE
Bug when layer cannot be filled

### DIFF
--- a/pyshipping/binpack_simple.py
+++ b/pyshipping/binpack_simple.py
@@ -79,6 +79,7 @@ def packlayer(bin, packages):
     while packages:
         strip, (sizex, stripsize, sizez), rest = packstrip(bin, packages)
         if layersize + stripsize <= binsize:
+            packages = rest
             if not strip:
                 # we were not able to pack anything
                 break
@@ -86,7 +87,6 @@ def packlayer(bin, packages):
             layerx = max([sizex, layerx])
             layery = max([sizez, layery])
             strips.extend(strip)
-            packages = rest
         else:
             # Next Layer please
             packages = strip + rest
@@ -104,6 +104,7 @@ def packbin(bin, packages):
     while packages:
         layer, (sizex, sizey, layersize), rest = packlayer(bin, packages)
         if contentheigth + layersize <= binsize:
+            packages = rest
             if not layer:
                 # we were not able to pack anything
                 break
@@ -111,7 +112,6 @@ def packbin(bin, packages):
             contentx = max([contentx, sizex])
             contenty = max([contenty, sizey])
             layers.extend(layer)
-            packages = rest
         else:
             # Next Bin please
             packages = layer + rest


### PR DESCRIPTION
I'm seeing a bug when the `packlayer` and `packbin` functions hit lines `84` abd `109` respectively.

The bug seems to be that since both those functions and the underlying `packstrip` modify the in-argument `packages`, when the fail reason is that no layer could be created, an empty list is returned instead of `rest` (because the `packages = rest` line is omitted from code)

Here's some code to reproduce the bug:

```
>>> from pyshipping import package, binpack_simple

>>> packages = [package.Package("80x30x20"), package.Package("120x30x20"), package.Package("120x30x20")]

>>> bin = package.Package("100x50x50")

>>> binpack_simple.binpack(packages, bin)
([[<Package 80x30x20>]], [])
```

see how the `rest` return value is empty instead of having the two packages too big to pack.

I don't completely understand in what circumstances the code breaks on those lines, and when does it break the other way (working properly), so I'm not certain my solution is the best approach, but it seems to work.
